### PR TITLE
Multicore graph generation

### DIFF
--- a/process_and_predict.py
+++ b/process_and_predict.py
@@ -14,6 +14,8 @@ from torch_geometric.loader import DataLoader
 from helpers import model_dict
 import argparse
 import time
+import sys
+
 from concurrent.futures import ProcessPoolExecutor, as_completed 
 
 def elements_to_atomicnums(elements):
@@ -542,7 +544,10 @@ def get_device(device_param):
         return torch.device("cpu")
     else:
         # Assume the user provided a valid CUDA device index
-        return torch.device(f"cuda:{device_param}")
+        if int(device_param) >= torch.cuda.device_count():
+            sys.exit(f"The CUDA device {device_param} doesn't seem to exist!")
+        else:
+            return torch.device(f"cuda:{device_param}")
 
 if __name__ == "__main__":    
     config = parse_args()


### PR DESCRIPTION
This update significantly improves the script's performance, reducing execution time from 80 seconds to 2.4 seconds on my system.

**Key Improvements:**
- Optimized Graph Generation
The initial implementation of ProcessPoolExecutor did not provide a significant speedup, I assume because each sample attempted to use all CPU cores simultaneously. To resolve this, I restricted each process to a single core using the following settings:

```python
os.environ["OMP_NUM_THREADS"] = "1"
os.environ["MKL_NUM_THREADS"] = "1"
torch.set_num_threads(1)
```
After graph processing, these settings are reset to allow the program to fully utilize all available cores again.

- New Configuration Options
Added explicit --num_workers and --device arguments to provide more control over execution. Users can now:

   - Run the script on the CPU explicitly.
   - Specify a particular CUDA device for execution.

**Outstanding Issue:**

- Inference Performance on CPU
A possible explanation is the difference between physical cores vs. hyperthreads—using 16 threads (the actual number of cores) yields the fastest performance, while increasing beyond that degrades efficiency. This is just a hypothesis, but it should not be a major concern when using CUDA or manually setting the number of threads, which is now easily configurable.