### PR TITLE
Handle invalid SDF paths in input CSV and update default model references

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ In order to make predictions, the model requires a *.csv* file with the followin
 - *sdf_file*, relative path to the ligand *.sdf* file
 - *pdb_file*, relative path to the protein *.pdb* file
 
-An example dataset is included in *data/example_dataset.csv* for this demo.
+You can refer to *data/example_dataset.csv* for a sample input file.
+
+A typical prediction can be run as follows:
 
 ```
 python process_and_predict.py --dataset_csv=data/example_dataset.csv --data_name=example --trained_model_name=model_GATv2Net_ligsim90_fep_benchmark
@@ -98,6 +100,4 @@ The script processes data in *dataset_csv*, and removes datapoints if:
 
 The script then creates graphs and pytorch data to run the AEV-PLIG model specified with *trained_model_name*.
 
-The predictions are saved under *output/predictions/data_name_predictions.csv*
-
-For the example dataset, the script takes around 20 seconds to run
+The predictions would saved under *output/predictions/data_name_predictions.csv*

--- a/process_and_predict.py
+++ b/process_and_predict.py
@@ -298,6 +298,10 @@ def process_data(config):
     non_readable = []
     rare_atoms_ids = []
     for index, row in tqdm(df.iterrows(), total=df.shape[0]):
+        if not os.path.isfile(row["sdf_file"]):
+            non_readable.append(row["unique_id"])
+            print(f"File not found for {row['unique_id']} at {row['sdf_file']}")
+            continue    
         suppl = Chem.SDMolSupplier(row["sdf_file"], removeHs=False)
         assert(len(suppl) == 1)
         lig = suppl[0]

--- a/process_and_predict.py
+++ b/process_and_predict.py
@@ -562,7 +562,7 @@ def make_predictions(config):
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--trained_model_name', type=str, default='20231116-181233_model_GATv2Net_pdbbind_core')
+    parser.add_argument('--trained_model_name', type=str, default='model_GATv2Net_ligsim90_fep_benchmark')
     parser.add_argument('--dataset_csv', type=str, default='data/example_dataset.csv')
     parser.add_argument('--data_name', type=str, default='example')
     parser.add_argument('--hidden_dim', type=int, default=256)


### PR DESCRIPTION
Fixes a crash when an invalid SDF file path is provided in the input CSV.

Previously, the script would fail when RDKit attempted to read a non-existent or invalid SDF file. This change adds a validation step to check file existence and skips invalid entries instead of crashing.

Additionally, the default for the `--trained_model_name` argument has been updated to match the currently included model files.